### PR TITLE
【RFR】修复go sdk int字段无法序列化，并将request bean中应该使用int的改为int

### DIFF
--- a/smn-sdk-go-example/MessageTemplateDemo.go
+++ b/smn-sdk-go-example/MessageTemplateDemo.go
@@ -39,16 +39,16 @@ func main() {
 		panic(err)
 	}
 
-	//// create message template
-	//CreateMessageTemplate(&tempClient)
-	//// query message template detail
-	//QueryMessageTemplateDetail(&tempClient)
-	//// list message template
+	// create message template
+	CreateMessageTemplate(&tempClient)
+	// query message template detail
+	QueryMessageTemplateDetail(&tempClient)
+	// list message template
 	ListMessageTemplate(&tempClient)
-	//// update message template
-	//UpdateMessageTemplate(&tempClient)
-	//// delete message template
-	//DeleteMessageTemplate(&tempClient)
+	// update message template
+	UpdateMessageTemplate(&tempClient)
+	// delete message template
+	DeleteMessageTemplate(&tempClient)
 }
 
 func CreateMessageTemplate(smnClient *client.SmnClient) {

--- a/smn-sdk-go-example/MessageTemplateDemo.go
+++ b/smn-sdk-go-example/MessageTemplateDemo.go
@@ -39,16 +39,16 @@ func main() {
 		panic(err)
 	}
 
-	// create message template
-	CreateMessageTemplate(&tempClient)
-	// query message template detail
-	QueryMessageTemplateDetail(&tempClient)
-	// list message template
+	//// create message template
+	//CreateMessageTemplate(&tempClient)
+	//// query message template detail
+	//QueryMessageTemplateDetail(&tempClient)
+	//// list message template
 	ListMessageTemplate(&tempClient)
-	// update message template
-	UpdateMessageTemplate(&tempClient)
-	// delete message template
-	DeleteMessageTemplate(&tempClient)
+	//// update message template
+	//UpdateMessageTemplate(&tempClient)
+	//// delete message template
+	//DeleteMessageTemplate(&tempClient)
 }
 
 func CreateMessageTemplate(smnClient *client.SmnClient) {
@@ -89,10 +89,12 @@ func QueryMessageTemplateDetail(smnClient *client.SmnClient) {
 
 func ListMessageTemplate(smnClient *client.SmnClient) {
 	request := smnClient.NewListMessageTemplateRequest()
-	request.Offset = "0"
-	request.Limit = "10"
+	request.Offset = 0
+	request.Limit = 10
 	request.MessageTemplateName = "template_test_by_zhangyx_for_go"
 	response, err := smnClient.ListMessageTemplate(request)
+	fmt.Println(request.GetUrl())
+
 	if err != nil {
 		fmt.Println("the request is error ", err)
 		return

--- a/smn-sdk-go-example/SmsDemo.go
+++ b/smn-sdk-go-example/SmsDemo.go
@@ -128,6 +128,8 @@ func ListSmsMsgReport(smnClient *client.SmnClient) {
 	request.StartTime = "1512625955366"
 	request.EndTime = "1512712355850"
 	request.SignId = "6be340e91e5241e4b5d85837e6709104"
+	request.Limit = 10
+	request.Offset = 0
 	response, err := smnClient.ListSmsMsgReport(request)
 	if err != nil {
 		fmt.Println("the request is error ", err)

--- a/smn-sdk-go-example/SubscriptionDemo.go
+++ b/smn-sdk-go-example/SubscriptionDemo.go
@@ -51,8 +51,8 @@ func main() {
 
 func ListSubscriptions(smnClient *client.SmnClient) {
 	request := smnClient.NewListSubscriptionsRequest()
-	request.Limit = "10"
-	request.Offset = "0"
+	request.Limit = 10
+	request.Offset = 0
 	response, err := smnClient.ListSubscriptions(request)
 	if err != nil {
 		fmt.Println("the request is error ", err)
@@ -69,8 +69,8 @@ func ListSubscriptions(smnClient *client.SmnClient) {
 
 func ListSubscriptionsByTopic(smnClient *client.SmnClient) {
 	request := smnClient.NewListSubscriptionsByTopicRequest()
-	request.Limit = "10"
-	request.Offset = "0"
+	request.Limit = 10
+	request.Offset = 0
 	request.TopicUrn = "urn:smn:cn-north-1:cffe4fc4c9a54219b60dbaf7b586e132:test_zhangyx_go"
 	response, err := smnClient.ListSubscriptionsByTopic(request)
 	if err != nil {

--- a/smn-sdk-go-example/TopicDemo.go
+++ b/smn-sdk-go-example/TopicDemo.go
@@ -3,16 +3,6 @@ package main
 import (
 	"github.com/SimpleMessageNotification/smn-sdk-go/smn-sdk-go/client"
 	"fmt"
-	//"net/http"
-	//"github.com/SimpleMessageNotification/smn-sdk-go/smn-sdk-go/commom"
-	//"time"
-	//"net/url"
-	//"crypto/tls"
-	"net/http"
-	"net/url"
-	"crypto/tls"
-	"github.com/SimpleMessageNotification/smn-sdk-go/smn-sdk-go/commom"
-	"time"
 )
 
 func main() {
@@ -123,8 +113,8 @@ func DeleteTopic(smnClient *client.SmnClient) {
 
 func ListTopic(smnClient *client.SmnClient) {
 	request := smnClient.NewListTopicRequest()
-	request.Limit = "10"
-	request.Offset = "0"
+	request.Limit = 10
+	request.Offset = 0
 	response, err := smnClient.ListTopic(request)
 	if err != nil {
 		fmt.Println("the request is error ", err)

--- a/smn-sdk-go/client/message_template_list.go
+++ b/smn-sdk-go/client/message_template_list.go
@@ -22,8 +22,8 @@ type ListMessageTemplateRequest struct {
 	*BaseRequest
 	MessageTemplateName string `json:"message_template_name"`
 	Protocol            string `json:"protocol"`
-	Limit               string `json:"limit"`
-	Offset              string `json:"offset"`
+	Limit               int `json:"limit"`
+	Offset              int `json:"offset"`
 }
 
 //the response data of list message template
@@ -32,6 +32,7 @@ type ListMessageTemplateResponse struct {
 	MessageTemplateCount int                   `json:"message_template_count"`
 	MessageTemplates     []MessageTemplateInfo `json:"message_templates"`
 }
+
 // message template data info
 type MessageTemplateInfo struct {
 	MessageTemplateName string   `json:"message_template_name"`
@@ -55,6 +56,8 @@ func (client *SmnClient) ListMessageTemplate(request *ListMessageTemplateRequest
 func (client *SmnClient) NewListMessageTemplateRequest() (request *ListMessageTemplateRequest) {
 	request = &ListMessageTemplateRequest{
 		BaseRequest: &BaseRequest{Headers: make(map[string]string)},
+		Offset:      0,
+		Limit:       100,
 	}
 	return
 }

--- a/smn-sdk-go/client/sms_list_msg_report.go
+++ b/smn-sdk-go/client/sms_list_msg_report.go
@@ -23,9 +23,9 @@ type ListSmsMsgReportRequest struct {
 	EndTime   string `json:"end_time"`
 	SignId    string `json:"sign_id"`
 	Mobile    string `json:"mobile"`
-	Status    string `json:"status"`
-	Limit     string `json:"limit"`
-	Offset    string `json:"offset"`
+	Status    int `json:"status"`
+	Limit     int `json:"limit"`
+	Offset    int `json:"offset"`
 }
 
 // the response data of list sms msg report
@@ -61,8 +61,8 @@ func (client *SmnClient) ListSmsMsgReport(request *ListSmsMsgReportRequest) (res
 func (client *SmnClient) NewListSmsMsgReportRequest() (request *ListSmsMsgReportRequest) {
 	request = &ListSmsMsgReportRequest{
 		BaseRequest: &BaseRequest{Headers: make(map[string]string)},
-		Offset:      "0",
-		Limit:       "100",
+		Offset:      0,
+		Limit:       100,
 	}
 	return
 }

--- a/smn-sdk-go/client/sms_list_msg_report.go
+++ b/smn-sdk-go/client/sms_list_msg_report.go
@@ -23,7 +23,7 @@ type ListSmsMsgReportRequest struct {
 	EndTime   string `json:"end_time"`
 	SignId    string `json:"sign_id"`
 	Mobile    string `json:"mobile"`
-	Status    int `json:"status"`
+	Status    string `json:"status"`
 	Limit     int `json:"limit"`
 	Offset    int `json:"offset"`
 }

--- a/smn-sdk-go/client/subscription_list.go
+++ b/smn-sdk-go/client/subscription_list.go
@@ -19,8 +19,8 @@ import (
 // the request data of list subscriptions
 type ListSubscriptionsRequest struct {
 	*BaseRequest
-	Limit  string `json:"limit"`
-	Offset string `json:"offset"`
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
 }
 
 // the response data of list subscriptions
@@ -54,8 +54,8 @@ func (client *SmnClient) ListSubscriptions(request *ListSubscriptionsRequest) (r
 func (client *SmnClient) NewListSubscriptionsRequest() (request *ListSubscriptionsRequest) {
 	request = &ListSubscriptionsRequest{
 		BaseRequest: &BaseRequest{Headers: make(map[string]string)},
-		Offset:      "0",
-		Limit:       "100",
+		Offset:      0,
+		Limit:       100,
 	}
 	return
 }

--- a/smn-sdk-go/client/subscription_list_bytopic.go
+++ b/smn-sdk-go/client/subscription_list_bytopic.go
@@ -21,8 +21,8 @@ import (
 type ListSubscriptionsByTopicRequest struct {
 	*BaseRequest
 	TopicUrn string `json:"-"`
-	Limit    string `json:"limit"`
-	Offset   string `json:"offset"`
+	Limit    int `json:"limit"`
+	Offset   int `json:"offset"`
 }
 
 // the response data of list subscriptions by topic
@@ -45,8 +45,8 @@ func (client *SmnClient) ListSubscriptionsByTopic(request *ListSubscriptionsByTo
 func (client *SmnClient) NewListSubscriptionsByTopicRequest() (request *ListSubscriptionsByTopicRequest) {
 	request = &ListSubscriptionsByTopicRequest{
 		BaseRequest: &BaseRequest{Headers: make(map[string]string)},
-		Offset:      "0",
-		Limit:       "100",
+		Offset:      0,
+		Limit:       100,
 	}
 	return
 }

--- a/smn-sdk-go/client/topic_list.go
+++ b/smn-sdk-go/client/topic_list.go
@@ -19,8 +19,8 @@ import (
 // the request data of list topic
 type ListTopicRequest struct {
 	*BaseRequest
-	Limit  string `json:"limit"`
-	Offset string `json:"offset"`
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
 }
 
 // the response data of list topic
@@ -51,8 +51,8 @@ func (client *SmnClient) ListTopic(request *ListTopicRequest) (response *ListTop
 func (client *SmnClient) NewListTopicRequest() (request *ListTopicRequest) {
 	request = &ListTopicRequest{
 		BaseRequest: &BaseRequest{Headers: make(map[string]string)},
-		Offset:      "0",
-		Limit:       "100",
+		Offset:      0,
+		Limit:       100,
 	}
 	return
 }

--- a/smn-sdk-go/util/url_util.go
+++ b/smn-sdk-go/util/url_util.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"io"
 	"strings"
+	"fmt"
 )
 
 // get the request query params
@@ -31,8 +32,9 @@ func GetQueryParams(request interface{}) (urlEncoded string, err error) {
 
 	urlEncoder := url.Values{}
 	for key, value := range result {
-		if value != "" {
-			urlEncoder.Add(key, value.(string))
+		str := fmt.Sprint(value)
+		if str != "" {
+			urlEncoder.Add(key, str)
 		}
 	}
 	urlEncoded = urlEncoder.Encode()


### PR DESCRIPTION
+ 问题想象：
    原SDK中get方法中int型序列化会失败，没有格式化成string。此次修复该问题



![image](https://user-images.githubusercontent.com/21001417/35730841-8a3c298e-084e-11e8-8088-3722d402f25e.png)
